### PR TITLE
Issues are open by default

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -54,7 +54,7 @@ pub fn issue_is_open<'a>(i: &Issue<'a>) -> Result<bool> {
         }
     }
 
-    return Ok(false);
+    return Ok(true);
 }
 
 pub fn issue_is_closed<'a>(i: &Issue<'a>) -> Result<bool> {


### PR DESCRIPTION
We should treat issues where no appropriate trailer is present as "open"
rather than as "closed" issues.